### PR TITLE
[AIRFLOW-3646] Add missing __init__.py

### DIFF
--- a/tests/test_plugins_manager_rbac.py
+++ b/tests/test_plugins_manager_rbac.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+
+from airflow.configuration import conf
+from airflow.www_rbac import app as application
+
+
+class PluginsTestRBAC(unittest.TestCase):
+    def setUp(self):
+        conf.load_test_config()
+        self.app, self.appbuilder = application.create_app(testing=True)
+
+    def test_flaskappbuilder_views(self):
+        from tests.plugins.test_plugin import v_appbuilder_package
+        appbuilder_class_name = str(v_appbuilder_package['view'].__class__.__name__)
+        plugin_views = [view for view in self.appbuilder.baseviews
+                        if view.blueprint.name == appbuilder_class_name]
+
+        self.assertTrue(len(plugin_views) == 1)
+
+        # view should have a menu item matching category of v_appbuilder_package
+        links = [menu_item for menu_item in self.appbuilder.menu.menu
+                 if menu_item.name == v_appbuilder_package['category']]
+
+        self.assertTrue(len(links) == 1)
+
+        # menu link should also have a link matching the name of the package.
+        link = links[0]
+        self.assertEqual(link.name, v_appbuilder_package['category'])
+        self.assertEqual(link.childs[0].name, v_appbuilder_package['name'])
+
+    def test_flaskappbuilder_menu_links(self):
+        from tests.plugins.test_plugin import appbuilder_mitem
+
+        # menu item should exist matching appbuilder_mitem
+        links = [menu_item for menu_item in self.appbuilder.menu.menu
+                 if menu_item.name == appbuilder_mitem['category']]
+
+        self.assertTrue(len(links) == 1)
+
+        # menu link should also have a link matching the name of the package.
+        link = links[0]
+        self.assertEqual(link.name, appbuilder_mitem['category'])
+        self.assertEqual(link.childs[0].name, appbuilder_mitem['name'])

--- a/tests/test_plugins_manager_www.py
+++ b/tests/test_plugins_manager_www.py
@@ -27,13 +27,11 @@ import unittest
 from flask.blueprints import Blueprint
 from flask_admin.menu import MenuLink, MenuView
 
-from airflow.configuration import conf
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import BaseOperator
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.executors.base_executor import BaseExecutor
-from airflow.www.app import cached_app
-from airflow.www_rbac import app as application
+from airflow.www.app import create_app
 
 
 class PluginsTest(unittest.TestCase):
@@ -67,7 +65,7 @@ class PluginsTest(unittest.TestCase):
         self.assertTrue(callable(plugin_macro))
 
     def test_admin_views(self):
-        app = cached_app()
+        app = create_app(testing=True)
         [admin] = app.extensions['admin']
         category = admin._menu_categories['Test Plugin']
         [admin_view] = [v for v in category.get_children()
@@ -75,52 +73,13 @@ class PluginsTest(unittest.TestCase):
         self.assertEqual('Test View', admin_view.name)
 
     def test_flask_blueprints(self):
-        app = cached_app()
+        app = create_app(testing=True)
         self.assertIsInstance(app.blueprints['test_plugin'], Blueprint)
 
     def test_menu_links(self):
-        app = cached_app()
+        app = create_app(testing=True)
         [admin] = app.extensions['admin']
         category = admin._menu_categories['Test Plugin']
         [menu_link] = [ml for ml in category.get_children()
                        if isinstance(ml, MenuLink)]
         self.assertEqual('Test Menu Link', menu_link.name)
-
-
-class PluginsTestRBAC(unittest.TestCase):
-    def setUp(self):
-        conf.load_test_config()
-        self.app, self.appbuilder = application.create_app(testing=True)
-
-    def test_flaskappbuilder_views(self):
-        from tests.plugins.test_plugin import v_appbuilder_package
-        appbuilder_class_name = str(v_appbuilder_package['view'].__class__.__name__)
-        plugin_views = [view for view in self.appbuilder.baseviews
-                        if view.blueprint.name == appbuilder_class_name]
-
-        self.assertTrue(len(plugin_views) == 1)
-
-        # view should have a menu item matching category of v_appbuilder_package
-        links = [menu_item for menu_item in self.appbuilder.menu.menu
-                 if menu_item.name == v_appbuilder_package['category']]
-
-        self.assertTrue(len(links) == 1)
-
-        # menu link should also have a link matching the name of the package.
-        link = links[0]
-        self.assertEqual(link.name, v_appbuilder_package['category'])
-        self.assertEqual(link.childs[0].name, v_appbuilder_package['name'])
-
-    def test_flaskappbuilder_menu_links(self):
-        from tests.plugins.test_plugin import appbuilder_mitem
-
-        # menu item should exist matching appbuilder_mitem
-        links = [menu_item for menu_item in self.appbuilder.menu.menu
-                 if menu_item.name == appbuilder_mitem['category']]
-
-        self.assertTrue(len(links) == 1)
-
-        # menu link should also have a link matching the name of the package.
-        link = links[0]
-        self.assertEqual(link.name, appbuilder_mitem['category'])
-        self.assertEqual(link.childs[0].name, appbuilder_mitem['name'])


### PR DESCRIPTION
test_plugins_manager_rbac.py:57 is failing because the test structure `plugins/test_plugin` does not have an __init__.py and is therefore not seen as a module by python.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [ ] Passes `flake8`
